### PR TITLE
Change 1M-1NT from forcing to semiforcing

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ all cases, but for the 2NT bids we use Puppet Stayman.
 ## After 1♥️/1♠️
 
 * 1♥️-1♠️ 4+♠️s, one round forcing
-* 1NT\* one round forcing
+* 1NT\* Semiforcing. Opener passes with the 11-13 5332, bids 4 card side suit or
+  rebids 6 card major otherwise.
 * 2/1 responses are game forcing and natural
 * If responder is a passed hand, all responses are nonforcing.
 * 2♥️/2♠️ Invitational with 3+ card support


### PR DESCRIPTION
In cases where opener has a minimum 5332 (maximums don't exist since they are opened 1NT), forcing 1NT means they rebid a 3 card suit, and then responder is often going to end up playing a 4-3 fit at 2 level. It seems better to me to just pass the 1NT, which will often get overbid by the balancing seat and then we can continue with good information. Any minor side fit will be an asset in 1NT anyway. This also means that any new suit by opener is guaranteed to be 4 cards, which seems like a huge asset.