### PR TITLE
Change jump raises to be preemptive

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ all cases, but for the 2NT bids we use Puppet Stayman.
 * 1♠️ 4+♠️s, one round forcing
 * 1NT Nonforcing
 * 2♣️ Game forcing, denies 4 card major.
+* 2♦️ Constructive raise
+* 3♦️ Preemptive raise
 * If responder is a passed hand, all responses are nonforcing.
 
 ## After 1♥️/1♠️
@@ -109,7 +111,7 @@ all cases, but for the 2NT bids we use Puppet Stayman.
         * Other suits: Short suit game try (2NT! asks for spades)
             * Responder bids 4♥️/4♠️ if they do not have wasted values in the suit
               bid, and 3♥️/3♠️ otherwise.
-* 3♥️/3♠️ Game forcing raise, slam seeking.
+* 3♥️/3♠️ Preemptive raise. Less than invitational with 4+ card support.
 * 4♥️/4♠️ To play
 
 ## After 1NT or 1♣️!-1♦️!-1NT


### PR DESCRIPTION
I think we both agree that the preemptive raise has more value than the slam seeking raise. I think we should just make this change now and think about the game forcing auctions later, though the priority of #6 should rise accordingly.