### PR TITLE
Adjust the balanced and 4441 responses to 1C

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,16 @@ all cases, but for the 2NT bids we use Puppet Stayman.
     * 3NT 24+ balanced, stayman and transfers available
 * 1♥️ 8+ 5+♥️s
 * 1♠️ 8+ 5+♠️s
-* 1NT 8+ balanced
+* 1NT 8-11 balanced
 * 2♣️ 8+ 5+♣️s
 * 2♦️ 8+ 5+♦️s
 * 2♥️! 8+ 4441 singleton heart
+    * After any of the 4441 responses, a bid below game by opener creates
+      agreement on the strain and responder will bid according to SRAAACA.
 * 2♠️! 8+ 4441 singleton spade
-* 2NT! 8+ 4441 singleton minor
+* 2NT! 12+ balanced
+* 3♣️ 8+ 4441 singleton club
+* 3♦️ 8+ 4441 singleton diamond
 
 ## After 1♦️\*
 


### PR DESCRIPTION
The 2NT response signalling 4441 with a singleton minor wouldn't save
bidding space if the location of the singleton needed clarification, and
always jump-bidding the singleton makes the responses more uniform. 2NT
is then open to split the balanced ranges, which should improve the
1C-1NT auctions as the player without the balanced hand should be in
better position to be captain.