### PR TITLE
Adjust meanings of 2C-2D-2NT

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ all cases, but for the 2NT bids we use Puppet Stayman.
 * 2♦️! Forcing, invitational or better
     * 2♥️ 4♥️s, minimum
     * 2♠️ 4♠️s, minimum
-    * 2NT! Minimum, no shortness, no 4 card major
+    * 2NT! Minimum, no 4 card major
     * 3♣️! Maximum with shortness, no 4 card major
         * 3♦️! Ask for shortness
             * 3♥️! Short hearts


### PR DESCRIPTION
Minimum hands with no shortness and no 4 card major did not have a
defined bid. This puts them into 2NT.