### PR TITLE
Make 1D-2C artificial game force

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ all cases, but for the 2NT bids we use Puppet Stayman.
 * 1♥️ 4+♥️s, one round forcing
 * 1♠️ 4+♠️s, one round forcing
 * 1NT Nonforcing
-* 2♣️ Game forcing, denies 4 card major.
+* 2♣️! Artificial game forcing. May have 4 card majors. Opener bids 4 card suits up the line.
 * 2♦️ Constructive raise
 * 3♦️ Preemptive raise
 * If responder is a passed hand, all responses are nonforcing.


### PR DESCRIPTION
Denying 4 card majors makes it hard to utilize bidding space after 1D-2C
without more conventions. Making 2C artificial game force also solves
issues where it was hard to express game forcing values after a major
fit was found.