### PR TITLE
Adjust balanced positives and add ask for 4 card majors

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,29 @@ all cases, but for the 2NT bids we use Puppet Stayman.
     * 3NT 24+ balanced, stayman and transfers available
 * 1♥️ 8+ 5+♥️s
 * 1♠️ 8+ 5+♠️s
-* 1NT 8-11 balanced
+* 1NT! 8-11 or 14+ balanced. After this opening, the first SRAAACA range is
+  8-11, then 14-16, etc.
+    * 2♣️! Asks for 4 card major. To keep auctions lower, use transfer responses:
+        * 2♦️! 4♥️s
+        * 2♥️! 4♠️s
+        * 2♠️! No 4 card major
+            * 2NT "sets" notrump and asks for SRAAACA.
+        * Opener can complete the transfer to confirm the fit, which initiates
+          SRAAACA, or bid another suit naturally to ask for support.
 * 2♣️ 8+ 5+♣️s
 * 2♦️ 8+ 5+♦️s
 * 2♥️! 8+ 4441 singleton heart
     * After any of the 4441 responses, a bid below game by opener creates
       agreement on the strain and responder will bid according to SRAAACA.
 * 2♠️! 8+ 4441 singleton spade
-* 2NT! 12+ balanced
+* 2NT! 12-13 balanced
+    * 3♣️! Asks for 4 card major. Similar to the 1NT response, use
+      transfer respones here as well.
+        * 3♦️! 4♥️s
+        * 3♥️! 4♠️s
+        * 3♠️! No 4 card major
+        * Completing the transfer at 3 level shows slam interest. Opener should
+          jump to game with minimum hands and a fit.
 * 3♣️! 8+ 4441 singleton club
 * 3♦️! 8+ 4441 singleton diamond
 


### PR DESCRIPTION
4-4 major fits will often be better than 3NT, and we are mostly unable
to find them when opener also has no 5 card suit (since the first suit
bid would be expected to be 5). Narrowing the 2NT range helps with the
fact that there is significantly less bidding space there, while the 1NT
responses tended to have extra that could be useful for slam bidding.

In the future, we might consider elaborating the system here. For
example, symmetric relay has the idea of "zooming" which is responding
to the next question before it's asked when you're giving the top answer
to the current question. We could do something similar here with after
1C-1NT-2C, 2NT and higher all show both majors, with each bid showing a
point range.