### PR TITLE
Adjust 2C responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,21 +456,54 @@ looking for a fit in one of responder's suits.
 
 ## After 2♣️!
 
-* 2♦️! Forcing, invitational or better
+* 2♦️! Asks for 4 card major, invitational or better, may not have a 4 card
+  major. Maximum responses establish a game force. ON for passed hands (fitting
+  hands can invite with less than 11, as clubs is providing us a source of
+  tricks).
     * 2♥️ 4♥️s, minimum
+        * 2NT To play, but opener can pull to 3♣️
+        * 3♣️ To play
     * 2♠️ 4♠️s, minimum
+        * 2NT To play, but opener can pull to 3♣️
+        * 3♣️ To play
     * 2NT! Minimum, no 4 card major
-    * 3♣️! Maximum with shortness, no 4 card major
+        * 3♣️ To play
+        * 3♦️! Game forcing, ask for shortness
+            * 3♥️! Short hearts
+            * 3♠️! Short spades
+            * 3NT! Short diamonds or no shortness
+        * 3♥️ Game forcing, 5♥️s
+        * 3♠️ Game forcing, 5♠️s
+        * Games To play
+    * 3♣️! Maximum with shortness, no 4 card major, establishes a game force
         * 3♦️! Ask for shortness
             * 3♥️! Short hearts
             * 3♠️! Short spades
             * 3NT! Short diamonds
-    * 3♦️! Maximum, no shortness, no 4 card major
-    * 3♥️ 4♥️s, maximum
-    * 3♠️ 4♠️s, maximum
-* 2♥️! Natural, nonforcing
-* 2♠️! Natural, nonforcing
-* 2NT Invite to 3NT
+        * 3♥️ 5♥️s
+        * 3♠️ 5♠️s
+        * Games To play
+    * 3♦️! Maximum, no shortness, no 4 card major, establishes a game force
+        * 3♥️ 5♥️s
+        * 3♠️ 5♠️s
+        * Games To play
+    * 3♥️ 4♥️s, maximum, establishes a game force
+    * 3♠️ 4♠️s, maximum, establishes a game force
+* 2♥️! 5+♥️s, nonforcing, up to invitational
+* 2♠️! 5+♠️s, nonforcing, up to invitational
+* 2NT! 5♠️s 4♥️s invitational, possibly 5-5 if spade quality is significantly
+  better.
+    * Opener places the contract
+* 3♣️ Nonforcing, preemptive
+* 3♦️ 5+♦️s, game forcing
+* 3♥️ 5+♥️s, game forcing
+* 3♠️ 5+♠️s, game forcing
+* 4♣️ Preemptive
+    * To get Minorwood, go through 2♦️ or 3X first.
+* 3NT, 4♥️, 4♠️, 5♣️, 5♦️ To play
+* If responder has a 6+ card major, they will generally choose 4 of that major
+  as the game to play without checking for support. In the case of 6-4 majors,
+  responder should go through 2♦️ to check for the possible 4-4 fit.
 
 ## After 2♦️!
 


### PR DESCRIPTION
I tried running simulations with 2D as a potentially garbage stayman
(and always responding at the lowest level when having a major), but the
frequency of hitting a 4-4 major fit was lower than the frequency of
going down an extra trick in clubs, and responder with 4-4 majors will
often do well to defend.

However, the 2NT invite showing 5S4H looked to be a winner when it came
up, so adding that and moving the natural 2NT invite into 2D a la
non-promissory Stayman.

Additionally, this change defines the club raises as preemptive, and the
3 level bids as natural game forces.