### PR TITLE
Make new suits after weak 2s nonforcing

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,8 @@ minimum are left unspecified, but adding a king to a maximum should take it
 outside of the preempt range, either to pass in hopes of a better constructive
 auction or to a one level opening.
 
-* New suits natural and forcing
+* New suits natural and nonforcing. All strong hands (with interest in game)
+  start with 2NT.
 * 2NT! Artificial inquiry, invitational or better. Note that because of the light
   preempting style, an invitational hand needs to be quite strong. This can also
   be used for investigating slam and is often better suited for that purpose as
@@ -563,7 +564,12 @@ auction or to a one level opening.
     * 3X! Maximum, 6 card suit and feature in the bid suit.
     * 3NT! Maximum, 6 card suit and no outside feature. If vulnerable, also
       denies shortage.
+    * After any of the above clarifications, responder may still introduce a
+      new suit naturally.
 * 2NT is ON in competition if available.
+* If the opponents double our weak 2 opening, then new suits are still
+  nonforcing, and redouble is SOS showing a desire to run but without a clear
+  suit preference.
 
 ## After 2NT or 1♣️!-1♦️!-2NT
 


### PR DESCRIPTION
Because our style opens weak 2s very light, hands with interest in game
are quite rare. Additionally, since we do not have strict requirements
on suit quality, hands where responder wants to be able to run to a
different suit even in the absence of a double are quite common.